### PR TITLE
[ADD]新規todo作成サンプルFormの作成

### DIFF
--- a/lib/create_todo_page.dart
+++ b/lib/create_todo_page.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+class CreateTodoPage extends StatefulWidget {
+  @override
+  _CreateTodoPageState createState() => _CreateTodoPageState();
+}
+
+class _CreateTodoPageState extends State<CreateTodoPage> {
+  var _todoController = TextEditingController();
+  var _text = '';
+  final myFocusNode = FocusNode();
+
+  void _submit() {
+      // 入力内容
+      _text = _todoController.text;
+    }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text("Todo新規作成"),
+      ),
+      body: Container(
+        padding: EdgeInsets.all(32.0),
+        child: Column(
+          children: [
+            Row(
+              children: <Widget>[
+                Expanded(
+                  flex: 3,
+                  child: Text('todo: '),
+                ),
+                Expanded(
+                  flex: 14,
+                  child: TextFormField(
+                    controller: _todoController,
+                    autofocus: true,
+                    decoration: InputDecoration(
+                      border: OutlineInputBorder(),
+                      hintText: 'todoに追加したい内容を入力',
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            RaisedButton(
+              child: Text('追加'),
+              onPressed: (){
+                _submit();
+              },
+            ),
+            Container(
+              padding: EdgeInsets.all(8.0),
+              child: Text(_text),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:sample_todo/completed_todo_page.dart'; //遷移先ページインポート
+import 'package:sample_todo/completed_todo_page.dart';
+import 'package:sample_todo/create_todo_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -93,7 +94,14 @@ class _MyHomePageState extends State<MyHomePage> {
         ],
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: _createTodo,
+        onPressed: () { // ボタン押したときに実行される
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => CreateTodoPage(), // SecondPageは遷移先のクラス
+            ),
+          );
+        },
         tooltip: 'todoチケットの新規作成',
         child: const Icon(Icons.add),
       ),


### PR DESCRIPTION
■概要
- todo作成用ページの作成
- メインページからtodo作成用ページへのリンク作成

■詳細
- todo作成用ページの作成
  - まずは入力したテキストをその画面で表示させるところまでにしておいた。ローカルDBとの連携などをする際に改めて接続部分などを書き直す。
- メインページからtodo作成用ページへのリンク作成
  - create_todo_page.dartへのリンクを作成（メインページの＋ボタン）