### PR TITLE
[ADD]complete_tasksへの導線+ページ作成

### DIFF
--- a/lib/pages/completed_tasks.dart
+++ b/lib/pages/completed_tasks.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:sample_todo/pages/app_background.dart';
+
+class CompletedTasks extends StatelessWidget {
+  const CompletedTasks({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      resizeToAvoidBottomInset: false,
+      appBar: AppBar(
+        title: Text('Completed Tasks'),
+        centerTitle: true,
+        actions: <Widget>[
+          // ③次項で作成するページです。
+          Padding(
+            padding: EdgeInsets.all(8.0),
+            child: IconButton(
+              icon: Icon(Icons.arrow_back),
+              onPressed: () {
+                // 一旦ここはコメントアウト
+                Navigator.pop(context);
+              },
+            ),
+          ),
+        ],
+      ),
+      body: Stack(
+        children: <Widget>[
+          AppBackgroundPage(),
+//Columnを使用することで二つのWidgetを重ねるように配置します
+          Column(
+            children: <Widget>[
+              //後に定義するインプットボックスウィジェットを呼び出します
+              Text('test'),
+              Text('test'),
+              //ここ変更
+              // InputContainer(validate, eCtrl, addListItem),
+              // // buildInputContainer(),
+              // //ここまで
+
+              // Expanded(
+              //   child: ListView.builder(
+              //     itemCount: tasks.length,
+              //     itemBuilder: (BuildContext context, int i) {
+              //       // List 一つのデザインを定義します。
+              //       //// 好みで変更してみてください。
+              //       return buildListItem(tasks, i);
+              //     },
+              //   ),
+              // )
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/list_page.dart
+++ b/lib/pages/list_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:intl/intl.dart';
 import 'package:sample_todo/components/input_container.dart';
+import 'package:sample_todo/pages/completed_tasks.dart';
 import 'package:sample_todo/db/task.dart';
 import 'package:sample_todo/pages/app_background.dart';
 // import 'package:sample_todo/pages/completed_task_page.dart';
@@ -99,22 +100,20 @@ class _ListPageState extends State<ListPage> {
           centerTitle: true,
           actions: <Widget>[
             // ③次項で作成するページです。
-//            Padding(
-//              padding: EdgeInsets.all(8.0),
-//              child: IconButton(
-//                icon: Icon(Icons.check_box),
-//                onPressed: () {
-//                  Navigator.push(
-//                    context,
-//                    MaterialPageRoute(
-//                      builder: (context) => CompletedTasks(
-//                        tasks: tasks,
-//                      ),
-//                    ),
-//                  );
-//                },
-//              ),
-//            ),
+            Padding(
+              padding: EdgeInsets.all(8.0),
+              child: IconButton(
+                icon: Icon(Icons.check_box),
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => CompletedTasks(),
+                    ),
+                  );
+                },
+              ),
+            ),
           ],
         ),
 //Stackを使用することによってZ軸上にWidgetを重ねることができます。


### PR DESCRIPTION
■概要
list_page.dartでapp_barへアイコン追加（completed_tasks.dartへの導線）
completed_tasuks.dart作成

■詳細
タスク一覧ページから完了済みタスクへの導線を追加。
また、完了済みタスクページはひとまず画面描画だけできるようにしておいた。